### PR TITLE
Ops: de-duplicate workflows, document release flow, enforce English-only

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,9 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
+        This repository is **English-only** for public-facing communication (issues/PRs/discussions/wiki/security).
+        Please write your report in English.
+
         **Before you continue:** Have you checked if this issue already exists?
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,6 +7,9 @@ body:
       value: |
         Thanks for taking the time to suggest a new feature!
 
+        This repository is **English-only** for public-facing communication (issues/PRs/discussions/wiki/security).
+        Please write your request in English.
+
   - type: textarea
     id: feature-description
     attributes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,11 @@ class TempETAPlugin(
 - **No dead code**: Remove all commented-out experiments
 - **Import order**: stdlib → third-party → octoprint → local
 
+### Repository communication (English only)
+
+- **All public-facing repository communication must be in English only**: GitHub Issues, Pull Requests, Discussions, Wiki pages, and Security advisories.
+- If a user writes in another language, respond in English and keep technical terms consistent.
+
 **When generating code**: Follow OctoPrint standards, use English, include docstrings, test edge cases, ensure thread safety, keep performance in mind.
 
 ```python

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+# Pull Request
+
+<!-- English only: please write PR descriptions and discussions in English. -->
+
+- What does this change do?
+
+## Checklist
+
+- [ ] Public-facing text is in English
+- [ ] Tests pass (`pytest`)
+- [ ] Lint/formatting passes (`pre-commit run --all-files`)
+- [ ] Docs updated (if needed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
+    tags: ["v*"]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -3,7 +3,12 @@ name: i18n
 on:
   pull_request:
   push:
-    branches: ["**"]
+    branches: ["main"]
+    tags: ["v*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing
+
+This repository uses a protected default branch (`main`). Releases are created via tags and GitHub Actions.
+
+## Release flow (protected `main`)
+
+1. Create a release branch
+
+   ```bash
+   git switch -c release/vX.Y.Z
+   ```
+
+2. Make the release changes
+   - Bump the version in `pyproject.toml`.
+   - Run local checks:
+
+     ```bash
+     pre-commit run --all-files
+     pytest
+     ```
+
+3. Open a Pull Request into `main`
+   - Wait for required CI checks to pass.
+   - Merge the PR.
+
+4. Create an annotated tag on the merge commit
+
+   Make sure your local `main` is up to date:
+
+   ```bash
+   git switch main
+   git pull --ff-only
+   ```
+
+   Then create and push the tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+5. Publish the GitHub Release
+
+   Pushing the tag triggers the `Release` workflow, which builds and attaches:
+   - `octoprint_tempeta-X.Y.Z.zip` (user installable)
+   - `octoprint_tempeta-latest.zip` (stable URL for docs)
+   - sdist + wheel
+
+   After the workflow completes, add release notes on GitHub.
+
+## Notes
+
+- Do not push directly to `main` (branch protection blocks it).
+- Keep public-facing communication in English (issues/PRs/discussions/wiki/security).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@
 
 If you believe you have found a security vulnerability in this project, please report it privately.
 
+Please write security reports in **English**.
+
 Preferred reporting channels:
 
 1. **GitHub Security Advisories** (recommended):


### PR DESCRIPTION
### **User description**
This PR addresses three maintenance items:

1) De-duplicate workflow runs
- CI and i18n no longer run twice for PR branches (push + pull_request).
- Push triggers are limited to main and v* tags.
- Added concurrency with cancel-in-progress.

2) Clarify the release/tagging flow
- Added RELEASING.md describing the protected-main release process (PR -> merge -> tag -> release workflow).

3) Enforce English-only communication
- Added explicit English-only notes to issue templates and SECURITY.md.
- Added a PR template reminding contributors to use English.
- Copilot instructions already include the English-only policy.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- De-duplicate CI and i18n workflows by limiting push triggers to main and v* tags

- Add concurrency groups with cancel-in-progress to prevent duplicate runs

- Document release flow with protected main branch and tag-based releases

- Enforce English-only communication across issues, PRs, and security reports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Triggers"] -->|"Limit to main/v*"| B["Reduced Duplicates"]
  A -->|"Add concurrency"| B
  C["Release Documentation"] -->|"RELEASING.md"| D["Clear Release Process"]
  E["Issue/PR Templates"] -->|"Add English-only notes"| F["Enforce English Communication"]
  G["SECURITY.md"] -->|"Add English requirement"| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bug_report.yml</strong><dd><code>Add English-only requirement to bug reports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/ISSUE_TEMPLATE/bug_report.yml

<ul><li>Added English-only requirement notice at the top of bug report <br>template<br> <li> Clarifies that public-facing communication must be in English</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653ef">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feature_request.yml</strong><dd><code>Add English-only requirement to feature requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/ISSUE_TEMPLATE/feature_request.yml

<ul><li>Added English-only requirement notice at the top of feature request <br>template<br> <li> Clarifies that public-facing communication must be in English</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cd">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>copilot-instructions.md</strong><dd><code>Add English-only communication guidelines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/copilot-instructions.md

<ul><li>Added new section "Repository communication (English only)"<br> <li> Specifies that all public-facing communication must be in English<br> <li> Provides guidance on responding to non-English contributions</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pull_request_template.md</strong><dd><code>Create pull request template with English requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/pull_request_template.md

<ul><li>Created new PR template file with English-only reminder<br> <li> Added checklist items for public-facing text, tests, linting, and docs<br> <li> Provides structure for PR descriptions and discussions</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6b">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RELEASING.md</strong><dd><code>Document release flow and protected main process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RELEASING.md

<ul><li>Created comprehensive release documentation for protected main branch <br>workflow<br> <li> Documents step-by-step release process from branch creation to GitHub <br>release<br> <li> Includes version bumping, testing, PR merge, tagging, and release <br>publication<br> <li> Adds notes about branch protection and English-only communication <br>requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785d">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SECURITY.md</strong><dd><code>Add English-only requirement to security reports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SECURITY.md

<ul><li>Added explicit requirement to write security reports in English<br> <li> Placed prominently after vulnerability reporting introduction</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Limit CI triggers and add concurrency deduplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Changed push trigger from all branches to only main and v* tags<br> <li> Added concurrency group with cancel-in-progress to prevent duplicate <br>runs<br> <li> Reduces duplicate workflow executions for PR branches</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>i18n.yml</strong><dd><code>Limit i18n triggers and add concurrency deduplication</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/i18n.yml

<ul><li>Changed push trigger from all branches to only main and v* tags<br> <li> Added concurrency group with cancel-in-progress to prevent duplicate <br>runs<br> <li> Reduces duplicate workflow executions for PR branches</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/3/files#diff-0900e06711d9dd80a4ed70509559d3553ce3a53e1bcbb2802bf70df4174514af">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

