### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Critical areas: changes here should always be reviewed by the maintainer.
+/.github/ @Ajimaru
+/octoprint_temp_eta/ @Ajimaru
+/translations/ @Ajimaru
+/tests/ @Ajimaru
+
+# Packaging / build / release metadata
+/pyproject.toml @Ajimaru
+/setup.py @Ajimaru
+/MANIFEST.in @Ajimaru
+/requirements.txt @Ajimaru
+
+# Dev tooling / hooks
+/.development/ @Ajimaru
+/.githooks/ @Ajimaru
+/.pre-commit-config.yaml @Ajimaru


### PR DESCRIPTION
### **User description**
Adds a .github/CODEOWNERS file so changes to critical areas require code owner review (once branch protection enables it).


___

### **PR Type**
Other


___

### **Description**
- Adds `.github/CODEOWNERS` file for code ownership governance

- Designates `@Ajimaru` as owner for critical areas

- Requires review for changes to core, tests, and build files

- Enables branch protection rules for code owner approval


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repository"] -- "defines code owners" --> B[".github/CODEOWNERS"]
  B -- "protects critical areas" --> C["Core Code"]
  B -- "protects critical areas" --> D["Tests"]
  B -- "protects critical areas" --> E["Build Config"]
  C --> F["@Ajimaru Review Required"]
  D --> F
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CODEOWNERS</strong><dd><code>Define code owners for critical repository areas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/CODEOWNERS

<ul><li>Creates new CODEOWNERS file with code ownership rules<br> <li> Assigns <code>@Ajimaru</code> as owner for critical directories and files<br> <li> Covers core package, tests, translations, and build configuration<br> <li> Includes development tooling and pre-commit configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/4/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

