### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Keep Python dependencies up to date
   - package-ecosystem: "pip"
@@ -13,3 +17,22 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      python-dev-tools:
+        patterns:
+          - "black"
+          - "flake8"
+          - "isort"
+          - "pre-commit"
+          - "pytest"
+          - "pytest-*"
+          - "coverage"
+          - "pytest-cov"
+          - "build"
+      python-build-system:
+        patterns:
+          - "setuptools"
+          - "wheel"
+      python-runtime:
+        patterns:
+          - "typing_extensions"


### PR DESCRIPTION
### **User description**
Reduce Dependabot PR noise by grouping updates:\n- one PR for GitHub Actions\n- grouped Python dev tools / build system / runtime deps\n\nThis does not change dependency versions by itself; it only changes how Dependabot batches updates.


___

### **PR Type**
Enhancement


___

### **Description**
- Configure Dependabot to group updates by category

- GitHub Actions updates grouped into single PR

- Python dependencies grouped by dev tools, build system, runtime

- Reduces PR noise from frequent dependency updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot Configuration"] --> B["GitHub Actions Group"]
  A --> C["Python Dev Tools Group"]
  A --> D["Python Build System Group"]
  A --> E["Python Runtime Group"]
  B -- "all actions" --> F["Single PR"]
  C -- "black, pytest, flake8, etc" --> G["Single PR"]
  D -- "setuptools, wheel" --> H["Single PR"]
  E -- "typing_extensions" --> I["Single PR"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Add Dependabot grouping configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>groups</code> configuration for GitHub Actions ecosystem<br> <li> Added <code>python-dev-tools</code> group for testing and linting tools<br> <li> Added <code>python-build-system</code> group for build dependencies<br> <li> Added <code>python-runtime</code> group for runtime dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/12/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

