### PR TITLE
Fix release workflow zip step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,37 +55,43 @@ jobs:
             exit 1
           fi
 
-          python - "$sdist" "$zip_versioned" <<'PY'
-          import sys
-          import tarfile
-          import zipfile
-          from pathlib import Path, PurePosixPath
+              python - "$sdist" "$zip_versioned" <<'PY'
+              import sys
+              import tarfile
+              import zipfile
+              from pathlib import Path, PurePosixPath
 
-          tar_path = Path(sys.argv[1])
-          zip_path = Path(sys.argv[2])
-          zip_path.parent.mkdir(parents=True, exist_ok=True)
+              tar_path = Path(sys.argv[1])
+              zip_path = Path(sys.argv[2])
+              zip_path.parent.mkdir(parents=True, exist_ok=True)
 
-          with tarfile.open(tar_path, "r:gz") as tf, zipfile.ZipFile(
-              zip_path, "w", compression=zipfile.ZIP_DEFLATED
-          ) as zf:
-              for member in tf.getmembers():
+              with tarfile.open(tar_path, "r:gz") as tf, zipfile.ZipFile(
+                zip_path, "w", compression=zipfile.ZIP_DEFLATED
+              ) as zf:
+                for member in tf.getmembers():
                   if not member.isfile():
-                      continue
+                    continue
 
-                # Defensive: ensure tar member paths cannot become path traversal entries in the zip.
-                # Tar archives always use POSIX-style paths.
-                member_path = PurePosixPath(member.name)
-                if member_path.is_absolute() or ".." in member_path.parts or ":" in member.name or member.name.startswith("\\"):
-                  continue
+                  # Defensive: ensure tar member paths cannot become path traversal entries in the zip.
+                  # Tar archives always use POSIX-style paths.
+                  member_path = PurePosixPath(member.name)
+                  if (
+                    member_path.is_absolute()
+                    or ".." in member_path.parts
+                    or ":" in member.name
+                    or member.name.startswith("\\")
+                  ):
+                    continue
 
                   extracted = tf.extractfile(member)
                   if extracted is None:
-                      continue
+                    continue
                   data = extracted.read()
-                zi = zipfile.ZipInfo(str(member_path))
+
+                  zi = zipfile.ZipInfo(str(member_path))
                   zi.external_attr = (member.mode & 0o777) << 16
                   zf.writestr(zi, data)
-          PY
+              PY
 
           cp -f "$zip_versioned" "$zip_latest"
 


### PR DESCRIPTION
### **User description**
Fixes an indentation issue in the Python heredoc used to generate the versioned + latest ZIP assets in the Release workflow.\n\nThis unblocks creating the v0.4.0 GitHub Release from the tag.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Python heredoc indentation in release workflow

- Correct nested indentation for tar-to-zip conversion script

- Improve code readability with proper formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Workflow"] -->|"Fix heredoc indentation"| B["Python Script"]
  B -->|"Convert tar to zip"| C["Versioned ZIP Asset"]
  C -->|"Copy"| D["Latest ZIP Asset"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix Python heredoc indentation in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Fixed indentation of Python heredoc script block for proper shell <br>execution<br> <li> Adjusted nested indentation levels for tar-to-zip conversion logic<br> <li> Reformatted conditional statement for path traversal validation across <br>multiple lines<br> <li> Improved code readability without changing functional behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/14/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+30/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

