### PR TITLE
Fix Release workflow heredoc indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,43 +55,43 @@ jobs:
             exit 1
           fi
 
-              python - "$sdist" "$zip_versioned" <<'PY'
-              import sys
-              import tarfile
-              import zipfile
-              from pathlib import Path, PurePosixPath
+            python - "$sdist" "$zip_versioned" <<'PY'
+            import sys
+            import tarfile
+            import zipfile
+            from pathlib import Path, PurePosixPath
 
-              tar_path = Path(sys.argv[1])
-              zip_path = Path(sys.argv[2])
-              zip_path.parent.mkdir(parents=True, exist_ok=True)
+            tar_path = Path(sys.argv[1])
+            zip_path = Path(sys.argv[2])
+            zip_path.parent.mkdir(parents=True, exist_ok=True)
 
-              with tarfile.open(tar_path, "r:gz") as tf, zipfile.ZipFile(
-                zip_path, "w", compression=zipfile.ZIP_DEFLATED
-              ) as zf:
-                for member in tf.getmembers():
-                  if not member.isfile():
-                    continue
+            with tarfile.open(tar_path, "r:gz") as tf, zipfile.ZipFile(
+              zip_path, "w", compression=zipfile.ZIP_DEFLATED
+            ) as zf:
+              for member in tf.getmembers():
+                if not member.isfile():
+                  continue
 
-                  # Defensive: ensure tar member paths cannot become path traversal entries in the zip.
-                  # Tar archives always use POSIX-style paths.
-                  member_path = PurePosixPath(member.name)
-                  if (
-                    member_path.is_absolute()
-                    or ".." in member_path.parts
-                    or ":" in member.name
-                    or member.name.startswith("\\")
-                  ):
-                    continue
+                # Defensive: ensure tar member paths cannot become path traversal entries in the zip.
+                # Tar archives always use POSIX-style paths.
+                member_path = PurePosixPath(member.name)
+                if (
+                  member_path.is_absolute()
+                  or ".." in member_path.parts
+                  or ":" in member.name
+                  or member.name.startswith("\\")
+                ):
+                  continue
 
-                  extracted = tf.extractfile(member)
-                  if extracted is None:
-                    continue
-                  data = extracted.read()
+                extracted = tf.extractfile(member)
+                if extracted is None:
+                  continue
+                data = extracted.read()
 
-                  zi = zipfile.ZipInfo(str(member_path))
-                  zi.external_attr = (member.mode & 0o777) << 16
-                  zf.writestr(zi, data)
-              PY
+                zi = zipfile.ZipInfo(str(member_path))
+                zi.external_attr = (member.mode & 0o777) << 16
+                zf.writestr(zi, data)
+            PY
 
           cp -f "$zip_versioned" "$zip_latest"
 


### PR DESCRIPTION
### **User description**
The Release workflow failed when generating ZIP assets because the Python heredoc was indented, so bash didn't recognize the closing delimiter and Python errored with unexpected indentation.\n\nThis aligns the heredoc and its body with the run block indentation so YAML de-indents it correctly for bash and Python.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed heredoc indentation in Release workflow Python script

- Aligned Python code block with run step indentation

- Resolved bash heredoc delimiter recognition issue

- Corrected Python unexpected indentation errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Misaligned heredoc<br/>in release.yml"] -- "Remove extra<br/>indentation" --> B["Properly aligned<br/>Python heredoc"]
  B -- "Bash recognizes<br/>closing delimiter" --> C["Python executes<br/>without errors"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Correct Python heredoc indentation in release workflow</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Removed 14 spaces of excess indentation from Python heredoc block<br> <li> Aligned heredoc opening delimiter with run step indentation level<br> <li> Aligned all Python code lines to match corrected indentation<br> <li> Aligned heredoc closing delimiter <code>PY</code> with opening delimiter</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/15/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+37/-37</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

