### PR TITLE
Fix Release workflow heredoc alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,43 +55,43 @@ jobs:
             exit 1
           fi
 
-            python - "$sdist" "$zip_versioned" <<'PY'
-            import sys
-            import tarfile
-            import zipfile
-            from pathlib import Path, PurePosixPath
+          python - "$sdist" "$zip_versioned" <<'PY'
+          import sys
+          import tarfile
+          import zipfile
+          from pathlib import Path, PurePosixPath
 
-            tar_path = Path(sys.argv[1])
-            zip_path = Path(sys.argv[2])
-            zip_path.parent.mkdir(parents=True, exist_ok=True)
+          tar_path = Path(sys.argv[1])
+          zip_path = Path(sys.argv[2])
+          zip_path.parent.mkdir(parents=True, exist_ok=True)
 
-            with tarfile.open(tar_path, "r:gz") as tf, zipfile.ZipFile(
+          with tarfile.open(tar_path, "r:gz") as tf, zipfile.ZipFile(
               zip_path, "w", compression=zipfile.ZIP_DEFLATED
-            ) as zf:
+          ) as zf:
               for member in tf.getmembers():
-                if not member.isfile():
-                  continue
+                  if not member.isfile():
+                      continue
 
-                # Defensive: ensure tar member paths cannot become path traversal entries in the zip.
-                # Tar archives always use POSIX-style paths.
-                member_path = PurePosixPath(member.name)
-                if (
-                  member_path.is_absolute()
-                  or ".." in member_path.parts
-                  or ":" in member.name
-                  or member.name.startswith("\\")
-                ):
-                  continue
+                  # Defensive: ensure tar member paths cannot become path traversal entries in the zip.
+                  # Tar archives always use POSIX-style paths.
+                  member_path = PurePosixPath(member.name)
+                  if (
+                      member_path.is_absolute()
+                      or ".." in member_path.parts
+                      or ":" in member.name
+                      or member.name.startswith("\\")
+                  ):
+                      continue
 
-                extracted = tf.extractfile(member)
-                if extracted is None:
-                  continue
-                data = extracted.read()
+                  extracted = tf.extractfile(member)
+                  if extracted is None:
+                      continue
+                  data = extracted.read()
 
-                zi = zipfile.ZipInfo(str(member_path))
-                zi.external_attr = (member.mode & 0o777) << 16
-                zf.writestr(zi, data)
-            PY
+                  zi = zipfile.ZipInfo(str(member_path))
+                  zi.external_attr = (member.mode & 0o777) << 16
+                  zf.writestr(zi, data)
+          PY
 
           cp -f "$zip_versioned" "$zip_latest"
 


### PR DESCRIPTION
### **User description**
The Release workflow still failed because the heredoc lines were indented two extra spaces compared to the run block, leaving leading spaces in the generated bash script. That prevented bash from matching the  delimiter and caused Python indentation errors.\n\nThis aligns the heredoc start/body/end with the rest of the run block.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix heredoc indentation in Release workflow

- Remove extra leading spaces from Python script

- Align heredoc delimiter with run block indentation

- Prevent bash parsing and Python indentation errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Misaligned heredoc<br/>with extra spaces"] -- "Remove leading<br/>indentation" --> B["Properly aligned<br/>heredoc content"]
  B -- "Correct bash<br/>parsing" --> C["Valid Python<br/>script execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Align heredoc indentation with run block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Removed 2 extra leading spaces from heredoc start delimiter and all <br>Python script lines<br> <li> Realigned heredoc body and end delimiter to match the run block <br>indentation level<br> <li> Fixed indentation of nested Python code blocks within the heredoc<br> <li> Corrected spacing for proper bash heredoc parsing and Python syntax <br>validation</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/16/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+33/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

