### PR TITLE
Release v0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "OctoPrint-TempETA"
-version = "0.4.0"
+version = "0.4.1"
 description = "OctoPrint plugin to show estimated time remaining for printer heating"
 authors = [
     {name = "Ajimaru", email = "ajimaru_gdr@pm.me"}


### PR DESCRIPTION
### **User description**
This bumps the project version to 0.4.1.

Reason: v0.4.0 release/tag became unrecoverable due to GitHub release/tag immutability issues. We re-release as v0.4.1 to provide a clean tag+release for Plugin Manager downloads.

No changes to CHANGELOG.md.


___

### **PR Type**
Other


___

### **Description**
- Bump project version from 0.4.0 to 0.4.1

- Re-release due to GitHub tag immutability issues

- Provides clean tag and release for plugin downloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version 0.4.0"] -- "Re-release due to tag issues" --> B["Version 0.4.1"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update project version number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Updated project version from 0.4.0 to 0.4.1<br> <li> Single line change in version field</ul>


</details>


  </td>
  <td><a href="https://github.com/Ajimaru/OctoPrint-TempETA/pull/17/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

