### PR TITLE
Improve settings binding and add printer stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ out
 .codacy/
 .venv-octoprint-*/
 .octoprint-master/
+.octoprint-devel/
 .cache/
 .claude/
 

--- a/octoprint_temp_eta/__init__.py
+++ b/octoprint_temp_eta/__init__.py
@@ -64,6 +64,20 @@ except ModuleNotFoundError:  # pragma: no cover
 
     octoprint = _OctoPrintStubs()  # type: ignore
 
+try:
+    import octoprint.printer as octoprint_printer  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+
+    class _OctoPrintPrinterStubs:
+        """Container exposing printer stubs under an octoprint-like namespace."""
+
+        class PrinterCallback:
+            """Stub for octoprint.printer.PrinterCallback."""
+
+            pass
+
+    octoprint_printer = _OctoPrintPrinterStubs()  # type: ignore
+
 
 # OctoPrint's mixin base classes don't ship type information. Provide typed
 # aliases so Pylance accepts them as valid base classes.
@@ -84,6 +98,9 @@ EventHandlerPluginBase: type[Any] = getattr(
 )  # type: ignore[attr-defined]
 SimpleApiPluginBase: type[Any] = getattr(
     octoprint.plugin, "SimpleApiPlugin", object
+)  # type: ignore[attr-defined]
+PrinterCallbackBase: type[Any] = getattr(
+    octoprint_printer, "PrinterCallback", object
 )  # type: ignore[attr-defined]
 
 try:
@@ -181,6 +198,7 @@ class PrinterLike(Protocol):
 
 
 class TempETAPlugin(
+    PrinterCallbackBase,
     StartupPluginBase,
     TemplatePluginBase,
     SettingsPluginBase,

--- a/octoprint_temp_eta/_version.py
+++ b/octoprint_temp_eta/_version.py
@@ -1,3 +1,3 @@
 """Single source for plugin version used by development tooling."""
 
-VERSION = "0.8.0"
+VERSION = "0.8.1dev1"

--- a/octoprint_temp_eta/_version.py
+++ b/octoprint_temp_eta/_version.py
@@ -1,3 +1,3 @@
 """Single source for plugin version used by development tooling."""
 
-VERSION = "0.8.1dev1"
+VERSION = "0.8.1"

--- a/octoprint_temp_eta/static/js/temp_eta.js
+++ b/octoprint_temp_eta/static/js/temp_eta.js
@@ -279,6 +279,12 @@ $(() => {
 			// With custom_bindings=True the settings template is injected lazily when the
 			// settings dialog opens. Bind it then, and guard against double-binding.
 			self.settings = self._resolveSettingsRoot();
+			if (!self.settings?.plugins?.temp_eta) {
+				// First-load race: settings can be temporarily unavailable right after
+				// startup or settings dialog open. Retry later instead of binding against
+				// an incomplete model.
+				return;
+			}
 			var $root = self._getSettingsDialogRoot();
 			if (!$root) {
 				return;
@@ -448,6 +454,16 @@ $(() => {
 				return true;
 			}
 
+			var rootEl = $root.get(0);
+			if (!$(rootEl).data("tempEtaKoBound")) {
+				// Avoid false negatives when the settings template is visible but KO
+				// binding has not completed yet.
+				self._bindSettingsIfNeeded();
+				if (!$(rootEl).data("tempEtaKoBound")) {
+					return true;
+				}
+			}
+
 			var ok = true;
 			var firstInvalid = null;
 
@@ -507,8 +523,8 @@ $(() => {
 		self._bindSettingsWithRetry = () => {
 			// The settings content is injected lazily; retry a few times to catch it.
 			var attempts = 0;
-			var maxAttempts = 10;
-			var delayMs = 50;
+			var maxAttempts = 60;
+			var delayMs = 100;
 
 			var tick = () => {
 				attempts += 1;

--- a/octoprint_temp_eta/static/js/temp_eta.js
+++ b/octoprint_temp_eta/static/js/temp_eta.js
@@ -278,13 +278,14 @@ $(() => {
 		self._bindSettingsIfNeeded = () => {
 			// With custom_bindings=True the settings template is injected lazily when the
 			// settings dialog opens. Bind it then, and guard against double-binding.
-			self.settings = self._resolveSettingsRoot();
-			if (!self.settings?.plugins?.temp_eta) {
+			var resolvedSettings = self._resolveSettingsRoot();
+			if (!resolvedSettings?.plugins?.temp_eta) {
 				// First-load race: settings can be temporarily unavailable right after
 				// startup or settings dialog open. Retry later instead of binding against
 				// an incomplete model.
 				return;
 			}
+			self.settings = resolvedSettings;
 			var $root = self._getSettingsDialogRoot();
 			if (!$root) {
 				return;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "octoprint-temp-eta"
-version = "0.8.0"
+version = "0.8.1dev1"
 description = "OctoPrint plugin to show estimated time remaining for printer heating"
 authors = [
     {name = "Ajimaru", email = "ajimaru_gdr@pm.me"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "octoprint-temp-eta"
-version = "0.8.1dev1"
+version = "0.8.1"
 description = "OctoPrint plugin to show estimated time remaining for printer heating"
 authors = [
     {name = "Ajimaru", email = "ajimaru_gdr@pm.me"}

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OctoPrint-TempETA 0.1.0\n"
 "Report-Msgid-Bugs-To: ajimaru_gdr@pm.me\n"
-"POT-Creation-Date: 2026-05-02 14:45+0200\n"
+"POT-Creation-Date: 2026-05-04 12:55+0200\n"
 "PO-Revision-Date: 2026-01-08 12:00+0000\n"
 "Last-Translator: \n"
 "Language: de\n"
@@ -158,7 +158,7 @@ msgstr "Cooldown abgeschlossen"
 msgid "Cooling color"
 msgstr "Abkühlfarbe"
 
-#: octoprint_temp_eta/__init__.py:2214
+#: octoprint_temp_eta/__init__.py:2232
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:606
 msgid "Defaults restored."
 msgstr "Standardeinstellungen wiederhergestellt."
@@ -708,7 +708,7 @@ msgstr "Zieltemperatur für die Kammer im Schwellwert-Modus."
 msgid "Target temperature for tool0 when using threshold mode."
 msgstr "Zieltemperatur für Tool0 im Schwellwert-Modus."
 
-#: octoprint_temp_eta/__init__.py:1941
+#: octoprint_temp_eta/__init__.py:1959
 #: octoprint_temp_eta/templates/temp_eta_navbar.jinja2:21
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:4
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:579

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OctoPrint-TempETA 0.1.0\n"
 "Report-Msgid-Bugs-To: ajimaru_gdr@pm.me\n"
-"POT-Creation-Date: 2026-05-02 14:45+0200\n"
+"POT-Creation-Date: 2026-05-04 12:55+0200\n"
 "PO-Revision-Date: 2026-01-08 12:00+0000\n"
 "Last-Translator: \n"
 "Language: en\n"
@@ -152,7 +152,7 @@ msgstr "Cooldown finished"
 msgid "Cooling color"
 msgstr ""
 
-#: octoprint_temp_eta/__init__.py:2214
+#: octoprint_temp_eta/__init__.py:2232
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:606
 msgid "Defaults restored."
 msgstr "Defaults restored."
@@ -685,7 +685,7 @@ msgstr "Target temperature for the chamber when using threshold mode."
 msgid "Target temperature for tool0 when using threshold mode."
 msgstr "Target temperature for tool0 when using threshold mode."
 
-#: octoprint_temp_eta/__init__.py:1941
+#: octoprint_temp_eta/__init__.py:1959
 #: octoprint_temp_eta/templates/temp_eta_navbar.jinja2:21
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:4
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:579

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-02 14:45+0200\n"
+"POT-Creation-Date: 2026-05-04 12:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Cooling color"
 msgstr ""
 
-#: octoprint_temp_eta/__init__.py:2214
+#: octoprint_temp_eta/__init__.py:2232
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:606
 msgid "Defaults restored."
 msgstr ""
@@ -645,7 +645,7 @@ msgstr ""
 msgid "Target temperature for tool0 when using threshold mode."
 msgstr ""
 
-#: octoprint_temp_eta/__init__.py:1941
+#: octoprint_temp_eta/__init__.py:1959
 #: octoprint_temp_eta/templates/temp_eta_navbar.jinja2:21
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:4
 #: octoprint_temp_eta/templates/temp_eta_settings.jinja2:579


### PR DESCRIPTION
Enhance the settings binding logic to increase retry attempts and add printer callback stubs for compatibility with `octoprint.printer`. Update the version to 0.8.1 and include `.octoprint-devel/` in `.gitignore`.

