### PR TITLE
Improve sidebar binding comments and update div ID for clarity

### DIFF
--- a/octoprint_temp_eta/_version.py
+++ b/octoprint_temp_eta/_version.py
@@ -1,3 +1,3 @@
 """Single source for plugin version used by development tooling."""
 
-VERSION = "0.9.0"
+VERSION = "0.9.1"

--- a/octoprint_temp_eta/static/js/temp_eta.js
+++ b/octoprint_temp_eta/static/js/temp_eta.js
@@ -671,7 +671,11 @@ $(() => {
 
 		self._ensureSidebarBound = () => {
 			// Sidebar DOM can be injected after the initial viewmodel binding;
-			// bind it lazily and only once.
+			// bind it lazily and only once. Bind the OctoPrint-generated wrapper
+			// (id="sidebar_plugin_temp_eta") — our inner content div
+			// (id="sidebar_plugin_temp_eta_content") lives inside that binding
+			// context via foreach and must NOT be bound separately, or its
+			// bindings freeze (duplicate-id / nested applyBindings conflict).
 			self._bindElementOnce(
 				"#sidebar_plugin_temp_eta",
 				"tempEtaKoBoundSidebar",

--- a/octoprint_temp_eta/templates/temp_eta_sidebar.jinja2
+++ b/octoprint_temp_eta/templates/temp_eta_sidebar.jinja2
@@ -1,4 +1,4 @@
-<div id="sidebar_plugin_temp_eta"
+<div id="sidebar_plugin_temp_eta_content"
      data-bind="visible: isComponentEnabled('sidebar') && displayHeaters().length > 0">
     <!-- ko foreach: displayHeaters() -->
     <div class="temp-eta-item" data-bind="css: $root.getETAClass($data)">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "octoprint-temp-eta"
-version = "0.9.0"
+version = "0.9.1"
 description = "OctoPrint plugin to show estimated time remaining for printer heating"
 authors = [
     {name = "Ajimaru", email = "ajimaru_gdr@pm.me"}

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Base topic"
 msgstr ""
 
-#: octoprint_temp_eta/static/js/temp_eta.js:2265
+#: octoprint_temp_eta/static/js/temp_eta.js:2269
 msgid "Bed"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Celsius + Fahrenheit (°C/°F)"
 msgstr ""
 
-#: octoprint_temp_eta/static/js/temp_eta.js:2266
+#: octoprint_temp_eta/static/js/temp_eta.js:2270
 msgid "Chamber"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Cooldown finished"
 msgstr ""
 
-#: octoprint_temp_eta/static/js/temp_eta.js:2282
+#: octoprint_temp_eta/static/js/temp_eta.js:2286
 msgid "Cooling"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgid ""
 "CPU)"
 msgstr ""
 
-#: octoprint_temp_eta/static/js/temp_eta.js:2284
+#: octoprint_temp_eta/static/js/temp_eta.js:2288
 msgid "Idle"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr ""
 msgid "Maintenance"
 msgstr ""
 
-#: octoprint_temp_eta/static/js/temp_eta.js:1606
+#: octoprint_temp_eta/static/js/temp_eta.js:1610
 msgid "Measured temperature"
 msgstr ""
 
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Target reached"
 msgstr ""
 
-#: octoprint_temp_eta/static/js/temp_eta.js:1616
+#: octoprint_temp_eta/static/js/temp_eta.js:1620
 msgid "Target temperature"
 msgstr ""
 


### PR DESCRIPTION
# Pull Request

This pull request includes a version bump to `0.9.1` and an important fix to the sidebar DOM binding logic to prevent binding conflicts in the OctoPrint Temp ETA plugin. The changes ensure that the Knockout bindings are applied correctly and avoid issues with duplicate IDs and nested bindings.

### Version bump
* Updated the plugin version to `0.9.1` in both `octoprint_temp_eta/_version.py` and `pyproject.toml` for release tracking. [[1]](diffhunk://#diff-871252fcfc3f8f9d0c40e7a7288b3bb60172ac622bbc9827a559fda28e857bdfL3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10)

### Sidebar binding and template fixes
* Improved the sidebar binding logic in `temp_eta.js` to clarify that only the OctoPrint-generated wrapper (`#sidebar_plugin_temp_eta`) should be bound, preventing duplicate or nested Knockout bindings that could freeze the UI.
* Changed the root `div` in `temp_eta_sidebar.jinja2` from `sidebar_plugin_temp_eta` to `sidebar_plugin_temp_eta_content` to separate the content container from the OctoPrint wrapper, aligning with the new binding logic.

- What does this change do?

## Checklist

- [ ] Public-facing text is in English
- [x] Tests pass (`pytest`)
- [x] Lint/formatting passes (`pre-commit run --all-files`)
- [ ] Docs updated (if needed)
- [ ] Workflow changes (if any) keep least-privilege `permissions:` and avoid `pull_request_target` unless strictly necessary
